### PR TITLE
Update and fix Python matrixing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,24 +10,43 @@ env:
   matrix:
     
     - CONDA_PY=27
+    - CONDA_PY=35
+    - CONDA_PY=36
   global:
     # The BINSTAR_TOKEN secure variable. This is defined canonically in conda-forge.yml.
     - secure: "d+5q0sPqOq1l0eUpHwcYEQSbplk1kqcrqXqNJIymPb1r5KgZoatTzzRk+J8D6kK6OxBo2M/UN2x96XAircg/5L6lgEoNSuXQqBW5GFkARtm0vFa73hXJk0DLTK0WGAZBvVkPfc4WRXkzXceqa5jnvTfxEvQuLY6U/A1KrJlNEtdpBBlzL9A3wt/BnYCoplJcEDq97Dt081btodnuBiHzcxvgauAYySWYA/FNjy80cYImjO4JeDRuyVAH6MYQLa4aaICyb9jqyf1bQ9fFD6e0SbwjfU6oA2CfdTPFfYKrtAV1a6DUulAGjt/OCDisWti+bmIipMNLNkVOd1ZoEinIR5K0veSLqk+TCbo2C9bEEl//7hN4CuTGdi14UXNe8FrNoTk/iQ1g4YeMrorM0FhMSPodly17VbvljcIiuradBichL2DWLcNe88zPMWZZFHDkdqqRMmjiGD2w/ZbGCat2aHkluUHYbbFAuNihYdzLhWmx6DXL9Bu/j1QaLHchbs7+swXVg+0uGrtYyK25PsrpoBq0iHOpRjhL/OnRvMZjbW0NIze9mC+0bRLme4h6saHzoR9EZyac7K4FY4uPBKRht8xS/4bh3+JQ6Donzn7LGqHrDa8GymNZdR+yfEQNzzMuz+8tutomZ5SibPPOgl1wJw92LxZ2dHCtfZvPzAAXJEo="
 
 
 before_install:
+    # Fast finish the PR.
+    - |
+      (curl https://raw.githubusercontent.com/conda-forge/conda-forge-build-setup-feedstock/master/recipe/ff_ci_pr_build.py | \
+          python - -v --ci "travis" "${TRAVIS_REPO_SLUG}" "${TRAVIS_BUILD_NUMBER}" "${TRAVIS_PULL_REQUEST}") || exit 1
+
     # Remove homebrew.
-    - brew remove --force --ignore-dependencies $(brew list)
-    - brew cleanup -s
-    - rm -rf $(brew --cache)
+    - |
+      echo ""
+      echo "Removing homebrew from Travis CI to avoid conflicts."
+      curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/uninstall > ~/uninstall_homebrew
+      chmod +x ~/uninstall_homebrew
+      ~/uninstall_homebrew -fq
+      rm ~/uninstall_homebrew
+
 
 install:
+    # Install Miniconda.
     - |
+      echo ""
+      echo "Installing a fresh version of Miniconda."
       MINICONDA_URL="https://repo.continuum.io/miniconda"
       MINICONDA_FILE="Miniconda3-latest-MacOSX-x86_64.sh"
       curl -L -O "${MINICONDA_URL}/${MINICONDA_FILE}"
       bash $MINICONDA_FILE -b
 
+    # Configure conda.
+    - |
+      echo ""
+      echo "Configuring conda."
       source /Users/travis/miniconda3/bin/activate root
       conda config --remove channels defaults
       conda config --add channels defaults

--- a/LICENSE
+++ b/LICENSE
@@ -1,5 +1,5 @@
 BSD 3-clause license
-Copyright (c) conda-forge
+Copyright (c) 2015-2017, conda-forge
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:

--- a/ci_support/fast_finish_ci_pr_build.sh
+++ b/ci_support/fast_finish_ci_pr_build.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+curl https://raw.githubusercontent.com/conda-forge/conda-forge-build-setup-feedstock/master/recipe/ff_ci_pr_build.py | \
+     python - -v --ci "circle" "${CIRCLE_PROJECT_USERNAME}/${CIRCLE_PROJECT_REPONAME}" "${CIRCLE_BUILD_NUM}" "${CIRCLE_PR_NUMBER}"

--- a/ci_support/run_docker_build.sh
+++ b/ci_support/run_docker_build.sh
@@ -24,12 +24,14 @@ show_channel_urls: true
 CONDARC
 )
 
+rm -f "$FEEDSTOCK_ROOT/build_artefacts/conda-forge-build-done"
+
 cat << EOF | docker run -i \
                         -v "${RECIPE_ROOT}":/recipe_root \
                         -v "${FEEDSTOCK_ROOT}":/feedstock_root \
                         -a stdin -a stdout -a stderr \
                         condaforge/linux-anvil \
-                        bash || exit $?
+                        bash || exit 1
 
 export BINSTAR_TOKEN=${BINSTAR_TOKEN}
 export PYTHONUNBUFFERED=1
@@ -41,10 +43,29 @@ conda clean --lock
 conda install --yes --quiet conda-forge-build-setup
 source run_conda_forge_build_setup
 
-# Embarking on 1 case(s).
+# Embarking on 3 case(s).
     set -x
     export CONDA_PY=27
     set +x
     conda build /recipe_root --quiet || exit 1
     upload_or_check_non_existence /recipe_root conda-forge --channel=main || exit 1
+
+    set -x
+    export CONDA_PY=35
+    set +x
+    conda build /recipe_root --quiet || exit 1
+    upload_or_check_non_existence /recipe_root conda-forge --channel=main || exit 1
+
+    set -x
+    export CONDA_PY=36
+    set +x
+    conda build /recipe_root --quiet || exit 1
+    upload_or_check_non_existence /recipe_root conda-forge --channel=main || exit 1
+touch /feedstock_root/build_artefacts/conda-forge-build-done
 EOF
+
+# double-check that the build got to the end
+# see https://github.com/conda-forge/conda-smithy/pull/337
+# for a possible fix
+set -x
+test -f "$FEEDSTOCK_ROOT/build_artefacts/conda-forge-build-done" || exit 1

--- a/circle.yml
+++ b/circle.yml
@@ -1,5 +1,6 @@
 checkout:
   post:
+    - ./ci_support/fast_finish_ci_pr_build.sh
     - ./ci_support/checkout_merge_commit.sh
 
 machine:

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -12,13 +12,14 @@ configure_args=(
 )
 
 if [ $PY3K = 1 ] ; then
-    # Work around a weakness in AM_CHECK_PYTHON_HEADERS. It finds the name of
-    # $PYTHON, then runs "$PYTHON-config" to get the header locations. On
-    # Unixy platforms, conda-build sets $PYTHON to "$PREFIX/bin/python", so
-    # the configure script adopts that value. But in Python 3 situations,
-    # Anaconda does not "$PREFIX/bin/python-config", so the header check
-    # fails. Anaconda does provide "python3-config", though, so if we just
-    # tweak the executable name, we work.
+    # Work around a weakness in AM_CHECK_PYTHON_HEADERS. It finds the Python
+    # interpreter and calls it $PYTHON, then runs "$PYTHON-config --includes"
+    # to get the needed C #include flags. On Unixy platforms, conda-build sets
+    # $PYTHON to "$PREFIX/bin/python", so the configure script adopts that
+    # value. But in Python 3 situations, Anaconda does not provide
+    # "$PREFIX/bin/python-config", so configure fails to figure out where the
+    # headers live. Anaconda does provide "python3-config", though, so if we
+    # just tweak the executable name, things work.
     configure_args+=(--with-python=python3)
 fi
 

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -11,7 +11,18 @@ configure_args=(
     --with-cairo
 )
 
-if [ -n "$OSX_ARCH" ] ; then
+if [ $PY3K = 1 ] ; then
+    # Work around a weakness in AM_CHECK_PYTHON_HEADERS. It finds the name of
+    # $PYTHON, then runs "$PYTHON-config" to get the header locations. On
+    # Unixy platforms, conda-build sets $PYTHON to "$PREFIX/bin/python", so
+    # the configure script adopts that value. But in Python 3 situations,
+    # Anaconda does not "$PREFIX/bin/python-config", so the header check
+    # fails. Anaconda does provide "python3-config", though, so if we just
+    # tweak the executable name, we work.
+    configure_args+=(--with-python=python3)
+fi
+
+if [ $(uname) = Darwin ] ; then
     LDFLAGS="$LDFLAGS -Wl,-rpath,$PREFIX/lib"
 fi
 

--- a/recipe/hugepaths.patch
+++ b/recipe/hugepaths.patch
@@ -1,5 +1,5 @@
---- Makefile.in.orig	2016-10-06 14:50:05.955243132 +0000
-+++ Makefile.in	2016-10-06 14:51:12.729258334 +0000
+--- ./Makefile.in.orig	2016-10-06 14:50:05.955243132 +0000
++++ ./Makefile.in	2016-10-06 14:51:12.729258334 +0000
 @@ -928,7 +928,7 @@
          PYTHONPATH=$(top_builddir):$(top_srcdir) \
          UNINSTALLED_INTROSPECTION_SRCDIR=$(top_srcdir) \

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,8 +1,8 @@
 {% set name = "gobject-introspection" %}
 {% set major = "1.51" %}
-{% set patch = "1" %}
+{% set patch = "3" %}
 {% set version = major ~ "." ~ patch %}
-{% set sha256 = "2c47e7632df936055b4e96f48315e2d392be10a0642ce11610fba5240e19772d" %}
+{% set sha256 = "80acbffd89452b8e30f8a50f46d64517a866ca63157bd1fa78bedb69f9de11c3" %}
 
 package:
   name: {{ name|lower }}
@@ -18,7 +18,7 @@ source:
 build:
   number: 0
   detect_binary_files_with_prefix: true
-  skip: true  # [win or not py27]
+  skip: true  # [win]
 
 requirements:
   build:
@@ -29,11 +29,12 @@ requirements:
     - glib 2.51.*
     - libffi 3.2.*
     - pkg-config  # [not win]
-    - python >=2.7,<3
+    - python
     - toolchain
   run:
     - glib 2.51.*
     - libffi 3.2.*
+    - python
 
 test:
   commands:


### PR DESCRIPTION
This package doesn't install anything in `$PREFIX/lib/python*`, but it turns out that it does depend on Python at run-time — as per #1. This PR causes us to matrix across Python versions properly. It also updates to a slightly newer upstream release.