### PR TITLE
Fix g-ir-scanner linking on GCC7 with dependent libraries

### DIFF
--- a/recipe/gcc7-rpath-link.patch
+++ b/recipe/gcc7-rpath-link.patch
@@ -1,0 +1,18 @@
+On the GCC7 toolchain, we need to pass `-rpath-link` to the compiler rather
+than just `-rpath`. This also works with the `toolchain_c` toolchain. The
+needed feature can be tested by attempting to build the `pygobject` or
+`poppler` feedstocks, which invoke this codepath in their builds.
+
+diff --git a/giscanner/ccompiler.py b/giscanner/ccompiler.py
+index d10327c..0fc08f8 100644
+--- a/giscanner/ccompiler.py
++++ b/giscanner/ccompiler.py
+@@ -157,7 +157,7 @@ class CCompiler(object):
+                         args.append('-rpath')
+                         args.append(library_path)
+                     else:
+-                        args.append('-Wl,-rpath,' + library_path)
++                        args.append('-Wl,-rpath-link,' + library_path)
+ 
+             runtime_paths.append(library_path)
+ 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -13,9 +13,10 @@ source:
   sha256: {{ sha256 }}
   patches:
     - hugepaths.patch
+    - gcc7-rpath-link.patch  # [linux]
 
 build:
-  number: 1000
+  number: 1001
   detect_binary_files_with_prefix: true
   skip: true  # [win]
 


### PR DESCRIPTION
We need to pass -rpath-link, not -rpath. Testing with pygobject indicates that this also keeps on working using the `toolchain_c` compiler toolchain.

In particular, I've used this package to successfully build [pygobject-feedstock#11](https://github.com/conda-forge/pygobject-feedstock/pull/11) using both `toolchain_c` and and GCC7, as well as [poppler-feedstock#25](https://github.com/conda-forge/poppler-feedstock/pull/25) on GCC7 with some patching. (Poppler doesn't work on `toolchain_cxx` because it needs C++14, while that older compiler only goes up to C++11.)
