### PR TITLE
Fix executables installed on Linux

### DIFF
--- a/recipe/meson-rpaths.patch
+++ b/recipe/meson-rpaths.patch
@@ -20,3 +20,27 @@ index 7b4b0d9..e0a5381 100644
    install_dir: giscannerdir,
 +  install_rpath: join_paths(get_option('prefix'), get_option('libdir')),
  )
+diff --git a/tools/meson.build b/tools/meson.build
+index 0bc33ba..635e9bf 100644
+--- a/tools/meson.build
++++ b/tools/meson.build
+@@ -44,6 +44,7 @@ gircompiler = executable('g-ir-compiler', 'compiler.c',
+     girepo_dep,
+   ],
+   install: true,
++  install_rpath: join_paths(get_option('prefix'), get_option('libdir')),
+ )
+ 
+ girgenerate = executable('g-ir-generate', 'generate.c',
+@@ -52,9 +53,11 @@ girgenerate = executable('g-ir-generate', 'generate.c',
+     girepo_dep,
+   ],
+   install: true,
++  install_rpath: join_paths(get_option('prefix'), get_option('libdir')),
+ )
+ 
+ girinspect = executable('g-ir-inspect', 'g-ir-inspect.c',
+   dependencies: girepo_dep,
+   install: true,
++  install_rpath: join_paths(get_option('prefix'), get_option('libdir')),
+ )

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -19,7 +19,7 @@ source:
     - gcc7-rpath-link.patch  # [linux]
 
 build:
-  number: 1000
+  number: 1001
   skip: true  # [py<35]
 
 requirements:
@@ -46,6 +46,8 @@ test:
   commands:
     - conda inspect linkages -p $PREFIX $PKG_NAME  # [not win]
     - conda inspect objects -p $PREFIX $PKG_NAME  # [osx]
+    - g-ir-scanner --help
+    - g-ir-compiler --help
 
 about:
   home: https://wiki.gnome.org/action/show/Projects/GObjectIntrospection

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -46,8 +46,8 @@ test:
   commands:
     - conda inspect linkages -p $PREFIX $PKG_NAME  # [not win]
     - conda inspect objects -p $PREFIX $PKG_NAME  # [osx]
-    - g-ir-scanner --help
-    - g-ir-compiler --help
+    - g-ir-scanner --help  # [not win]
+    - g-ir-compiler --help  # [not win]
 
 about:
   home: https://wiki.gnome.org/action/show/Projects/GObjectIntrospection


### PR DESCRIPTION
Newer Meson apparently is more aggressive about stripping rpaths from installed executables, so the binary tools installed on Linux didn't work anymore. Manually tell Meson to keep the rpaths in the installed executables, and add tests to try to catch this in the future.

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a fork of the feedstock to propose changes
* [x] Bumped the build number (the version is unchanged)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.