### PR TITLE
Fix prefix replacement

### DIFF
--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -20,7 +20,17 @@ set PKG_CONFIG_PATH=%LIBRARY_PREFIX_M%/lib/pkgconfig;%LIBRARY_PREFIX_M%/share/pk
 set "PYTHONLEGACYWINDOWSSTDIO=1"
 set "PYTHONIOENCODING=UTF-8"
 
-%PYTHON% %PREFIX%\Scripts\meson --buildtype=release --prefix=%LIBRARY_PREFIX_M% --backend=ninja -Dcairo=enabled -Dcairo-libname=cairo-gobject.dll -Dpython=%PYTHON% ..
+@REM Pass Python to meson with a mixed-style (forward slash) path. This fixes a bug
+@REM where build prefix replacement would fail with the g-ir-scanner and
+@REM g-ir-annotation-tool Python scripts because the build prefix would appear within
+@REM them having two slash styles (forward and backward slashes). With this fix, the
+@REM Python path inserted at the top of the installed Python scripts will use the same
+@REM forward slash style as with the paths that meson substitutes later in those scripts
+@REM (meson will use forward slash no matter what style of prefix is passed, so have to
+@REM fix the env python path to match).
+FOR /F "delims=" %%i IN ('cygpath.exe -m "%PYTHON%"') DO set "PYTHON_M=%%i"
+
+%PYTHON% %PREFIX%\Scripts\meson --buildtype=release --prefix=%LIBRARY_PREFIX_M% --backend=ninja -Dcairo=enabled -Dcairo-libname=cairo-gobject.dll -Dpython=%PYTHON_M% ..
 if errorlevel 1 exit 1
 
 ninja -v

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -16,7 +16,7 @@ source:
     - test-fix.patch  # [linux]
 
 build:
-  number: 0
+  number: 1
   skip: true  # [py<35]
 
 requirements:
@@ -46,7 +46,8 @@ test:
     - conda inspect linkages -p $PREFIX $PKG_NAME  # [not win]
     - conda inspect objects -p $PREFIX $PKG_NAME  # [osx]
     - g-ir-scanner --help  # [not win]
-    - g-ir-compiler --help  # [not win]
+    - python "%PREFIX%\\Library\\bin\\g-ir-scanner" --help  # [win]
+    - g-ir-compiler --help
 
     # check that g-ir-scanner can be found through pkg-config (used by downstream builds)
     - test -f `pkg-config --variable=g_ir_scanner --dont-define-prefix gobject-introspection-1.0`  # [unix]


### PR DESCRIPTION
<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [x] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
This fixes a bug where build prefix replacement would fail with the g-ir-scanner and g-ir-annotation-tool Python scripts because the build prefix would appear within them having two slash styles (forward and backward slashes). With this fix, the Python path inserted at the top of the installed Python scripts will use the same forward slash style as with the paths that meson substitutes later in those scripts (meson will use forward slash no matter what style of prefix is passed, so have to fix the env python path to match).

The failed build prefix replacement on g-ir-scanner is resulting in failed builds for at least https://github.com/conda-forge/gdk-pixbuf-feedstock/pull/22 and https://github.com/conda-forge/gtk3-feedstock/pull/9.