### PR TITLE
recipe/build.sh: fix typo in cross-build script

### DIFF
--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -19,8 +19,8 @@ if [[ "$CONDA_BUILD_CROSS_COMPILATION" == 1 ]]; then
     pushd build-host
 
     export CC=$CC_FOR_BUILD
-    export AR=($CC_FOR_BUILD -print-prog-name=ar)
-    export NM=($CC_FOR_BUILD -print-prog-name=nm)
+    export AR="$($CC_FOR_BUILD -print-prog-name=ar)"
+    export NM="$($CC_FOR_BUILD -print-prog-name=nm)"
     export LDFLAGS=${LDFLAGS//$PREFIX/$BUILD_PREFIX}
     export PKG_CONFIG_PATH=${BUILD_PREFIX}/lib/pkgconfig
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -18,7 +18,7 @@ source:
     - pkg-config.patch
 
 build:
-  number: 3
+  number: 4
   skip: true  # [py<35]
 
 requirements:


### PR DESCRIPTION
Typo fix for the cross-build script. See also conda-forge/librsvg-feedstock#77, conda-forge/pango-feedstock#45, conda-forge/gtk3-feedstock#39.

Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.