### PR TITLE
Hardcode prefix in gobject python based tools

### DIFF
--- a/recipe/0002-use-prefix-python-in-tools.patch
+++ b/recipe/0002-use-prefix-python-in-tools.patch
@@ -1,0 +1,12 @@
+diff -ur a/tools/meson.build b/tools/meson.build
+--- a/tools/meson.build	2022-09-17 14:52:38.000000000 -0400
++++ b/tools/meson.build	2023-04-01 23:46:27.513915405 -0400
+@@ -12,7 +12,7 @@
+ if cc.get_id() == 'msvc'
+   python_cmd = '/usr/bin/env ' + python.path()
+ else
+-  python_cmd = '/usr/bin/env python@0@'.format(python.language_version().split('.')[0])
++  python_cmd = join_paths(get_option('prefix'), 'bin', 'python')
+ endif
+ 
+ tool_output = []

--- a/recipe/0002-use-prefix-python-in-tools.patch
+++ b/recipe/0002-use-prefix-python-in-tools.patch
@@ -6,7 +6,7 @@ diff -ur a/tools/meson.build b/tools/meson.build
    python_cmd = '/usr/bin/env ' + python.path()
  else
 -  python_cmd = '/usr/bin/env python@0@'.format(python.language_version().split('.')[0])
-+  python_cmd = join_paths(get_option('prefix'), 'bin', 'python')
++  python_cmd = join_paths(join_paths(get_option('prefix'), 'bin'), 'python')
  endif
  
  tool_output = []

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -19,9 +19,10 @@ source:
     - pkg-config.patch
     # workaround for conflicting "import ast", should not be necessary once PyPy is updated
     - 0001-Don-t-add-build_root-giscanner-to-PYTHONPATH-for-run.patch
+    - 0002-use-prefix-python-in-tools.patch
 
 build:
-  number: 1
+  number: 2
   skip: true  # [py<35]
 
 requirements:


### PR DESCRIPTION
I'm not really sure if this is an improvement, i'm still trying to fix my cross compilation of libvips and this seems to have been related, though this may not be the best solution to this particular challenge I am facing

Closes https://github.com/conda-forge/gobject-introspection-feedstock/issues/64

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [ ] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
